### PR TITLE
Add tooltip when hovering title

### DIFF
--- a/client/src/components/books/BookCard.vue
+++ b/client/src/components/books/BookCard.vue
@@ -81,7 +81,7 @@ const volume = computed(() => {
                   'focus-visible:ring-2 focus-visible:ring-black dark:focus-visible:ring-white/90',
                 ]"
               >
-                <span class="absolute inset-0 z-20 rounded-xl" />
+                <span :title="`${book?.attributes.title}`" class="absolute inset-0 z-20 rounded-xl" />
                 <span>{{ book?.attributes.title }}</span>
               </RouterLink>
               <span class="font-medium text-xxs sm:text-xs">
@@ -113,7 +113,7 @@ const volume = computed(() => {
           'focus-visible:ring-2 focus-visible:ring-black dark:focus-visible:ring-white/90',
         ]"
       >
-        <span class="absolute inset-0 z-20 rounded-xl" />
+        <span :title="`${book?.attributes.title}`" class="absolute inset-0 z-20 rounded-xl" />
         <span>{{ book?.attributes.title }}</span>
       </RouterLink>
       <span

--- a/client/src/components/books/BooksTable.vue
+++ b/client/src/components/books/BooksTable.vue
@@ -107,7 +107,7 @@ const columns = [
             emptyIcon: BookOpenIcon,
           }),
           h('div', { class: 'flex flex-col' }, [
-            h('span', { innerText: title, class: 'font-medium' }),
+            h('span', { innerText: title, class: 'font-medium', title: title }),
             subtitle.length > 0 ? h('span', { innerText: subtitle, class: 'text-xs text-gray-700 dark:text-gray-400' }) : undefined,
           ]),
         ])


### PR DESCRIPTION
Adds a little tooltip when hovering grid card (as the grid title is blocked by `absolute inset-0 z-20 rounded-xl` span) or list title

![image](https://github.com/alessandrojean/tankobon/assets/6576096/f7a4069f-fd16-4b23-b1a2-03302d2ee582)
