### PR TITLE
Add flags endpoint to permitAll() in SecurityConfiguration

### DIFF
--- a/server/src/main/kotlin/io/github/alessandrojean/tankobon/infrastructure/security/SecurityConfiguration.kt
+++ b/server/src/main/kotlin/io/github/alessandrojean/tankobon/infrastructure/security/SecurityConfiguration.kt
@@ -57,6 +57,7 @@ class SecurityConfiguration(
             "/index.html",
             "/fonts/**",
             "/assets/**",
+            "/flags/**",
           )
           .permitAll()
 


### PR DESCRIPTION
This commit adds the "/flags/**" endpoint to the list of URLs that are permitted for all users in the SecurityConfiguration class.

fixes #34