### PR TITLE
Add Swagger UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ guide before getting started.
 
 Check the documentation at the website (to be written).
 
+### API
+
+For the API there is a OpenAPI V3 documentation included with the server. It can be accessed through `/docs/swagger-ui.html` for a graphical experience, or through `/docs/openapi-v3` or `/docs/openapi-v3.yaml` to get the Tankobon OpenAPI V3 specification in a raw format.
+
 ## Project structure
 
 Tankobon has a monorepo structure.

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -73,8 +73,7 @@ dependencies {
   implementation("org.zalando:jackson-datatype-money:1.3.0")
 
   val springdocVersion = "2.0.2"
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-api:$springdocVersion")
-  implementation("org.springdoc:springdoc-openapi-starter-common:$springdocVersion")
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:$springdocVersion")
 
   val luceneVersion = "9.5.0"
   implementation("org.apache.lucene:lucene-core:$luceneVersion")

--- a/server/src/main/kotlin/io/github/alessandrojean/tankobon/infrastructure/security/SecurityConfiguration.kt
+++ b/server/src/main/kotlin/io/github/alessandrojean/tankobon/infrastructure/security/SecurityConfiguration.kt
@@ -44,10 +44,10 @@ class SecurityConfiguration(
 
         auth
           .requestMatchers(
+            "/docs/**",
             "/api/v1/system-status",
             "/api/v1/claim",
             "/api",
-            "/api/api-docs/**",
             "/images/**",
             "/set-cookie",
             "/error**",

--- a/server/src/main/kotlin/io/github/alessandrojean/tankobon/interfaces/api/rest/dto/BookDto.kt
+++ b/server/src/main/kotlin/io/github/alessandrojean/tankobon/interfaces/api/rest/dto/BookDto.kt
@@ -92,6 +92,11 @@ enum class ReferenceExpansionBook : ReferenceExpansionEnum {
   NEXT_BOOK,
 }
 
+@Schema(
+  type = "object",
+  title = "CodeDto",
+  subTypes = [SimpleCodeDto::class, IsbnCodeDto::class],
+)
 interface CodeDto {
   val type: CodeType
   val code: String
@@ -102,6 +107,11 @@ data class SimpleCodeDto(
   override val code: String,
 ) : CodeDto
 
+@Schema(
+  type = "object",
+  title = "IsbnCodeDto",
+  description = "When type is of ISBN-13 or ISBN-10",
+)
 data class IsbnCodeDto(
   override val type: CodeType,
   override val code: String,

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -74,5 +74,7 @@ management:
 springdoc:
   writer-with-order-by-keys: true
   default-produces-media-type: application/json
+  swagger-ui:
+    path: /docs/swagger-ui.html
   api-docs:
-    path: /api/api-docs
+    path: /docs/openapi-v3


### PR DESCRIPTION
- Replace `springdoc-openapi-starter-webmvc-api` with `springdoc-openapi-starter-webmvc-ui`
- Add `/docs/**` endpoint to SecurityConfiguration
- Change Swagger UI path to `/docs/swagger-ui.html`
- Change OpenAPI v3 path to `/docs/openapi-v3`

![image](https://github.com/alessandrojean/tankobon/assets/6576096/d20fe495-a270-4484-bd11-941974d0e363)
